### PR TITLE
Fix typo in license line of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Asking ChatGPT 4 to write me a Python personal financial simulator and optimizat
 
 Done for fun, personal, use, checking how many bugs ChatGPT 4 was able to introduce and I could discover/correct with him.  
 
-Licensed as ttribution-NonCommercial-ShareAlike 2.0 Generic (CC BY-NC-SA 2.0).
+Licensed as Attribution‑NonCommercial‑ShareAlike 2.0 Generic (CC BY-NC-SA 2.0).
 
 The content and code provided in this context were produced outside of my professional work, during my personal free time, and are not affiliated with, nor influenced by, any of my current or previous employers. The materials and information shared are for illustrative purposes only and should not be construed as financial advice. Always consult with a financial professional before making any financial decisions. I do not accept any responsibility or liability for the accuracy, content, completeness, legality, or reliability of the information provided here. Use this material and any resultant outcomes at your own risk.
 


### PR DESCRIPTION
## Summary
- fix a typo in the README license line

## Testing
- `grep -n "Licensed as" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_683f58a4529c83219a6070b486083347