### PR TITLE
Fix contribution logic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,70 @@
+import sys
+import types
+
+# Provide a minimal numpy module so utils can be imported without the real dependency
+sys.modules['numpy'] = types.ModuleType('numpy')
+
+from utils import compute_net_worth_over_time
+from bank_account import BankAccount
+
+class DummyInvestment:
+    def __init__(self):
+        self.typology = 'stock'
+        self.monthly_contribution = 0
+        self.current_value = 0
+        self.added_counts = 0
+    def step(self):
+        return None
+    def add_contribution(self, amount):
+        if amount:
+            self.added_counts += 1
+        # mimic small fee like real implementation
+        self.current_value += amount - 50
+
+class DummyIncome:
+    def __init__(self, amount):
+        self.amount = amount
+    def step(self):
+        return self.amount
+
+class DummyExpense:
+    def __init__(self, amount):
+        self.amount = amount
+    def step(self):
+        return self.amount
+
+def test_contribution_limit_and_variable_use():
+    bank = BankAccount(initial_balance=20000)
+    inv = DummyInvestment()
+    income = DummyIncome(1000)
+    expense = DummyExpense(100)
+
+    compute_net_worth_over_time(
+        years=1,
+        bank_account=bank,
+        investments=[inv],
+        loans=[],
+        income_sources=[income],
+        expenses=[expense]
+    )
+
+    assert inv.added_counts == 3
+
+
+def test_contributions_reset_each_year():
+    bank = BankAccount(initial_balance=20000)
+    inv = DummyInvestment()
+    income = DummyIncome(1000)
+    expense = DummyExpense(100)
+
+    compute_net_worth_over_time(
+        years=2,
+        bank_account=bank,
+        investments=[inv],
+        loans=[],
+        income_sources=[income],
+        expenses=[expense]
+    )
+
+    assert inv.added_counts == 6
+

--- a/utils.py
+++ b/utils.py
@@ -22,11 +22,10 @@ def compute_net_worth_over_time(years, bank_account, investments, loans, income_
     loan_repayment_dates = {}
      
 
-    year_income = 0
-    year_expense = 0
-    
     for year in range(years):
         additional_contributions = 0
+        year_income = 0
+        year_expense = 0
         
         for month in range(12):
             current_month = year * 12 + month  # Counting months from the start
@@ -74,16 +73,14 @@ def compute_net_worth_over_time(years, bank_account, investments, loans, income_
             
 
             # Yearly additional to stocks
-            if bank_account.subaccounts['Main'] > 10000 and additional_contributions<3: #todo monthly
-              if year_expense<year_income*0.8:
-                  stock_inv = list(filter(lambda x: x.typology=='stock',my_investments))[0]
-                  x=bank_account.total_balance()*0.1
-                  bank_account.withdraw(x, account_name="Main")
-                  stock_inv.add_contribution(x)
+            if bank_account.subaccounts['Main'] > 10000 and additional_contributions < 3:  # todo monthly
+                if year_expense < year_income * 0.8:
+                    stock_inv = list(filter(lambda x: x.typology == 'stock', investments))[0]
+                    x = bank_account.total_balance() * 0.1
+                    bank_account.withdraw(x, account_name="Main")
+                    stock_inv.add_contribution(x)
+                    additional_contributions += 1
 
-            year_income = 0
-            year_expense = 0
-            
             # Compute net worth for the month
             net_worth = get_net_worth(investments, loans, bank_account)
             monthly_net_worth.append(net_worth)


### PR DESCRIPTION
## Summary
- reset yearly counters at start of each year
- use provided `investments` parameter for stock contributions
- increment `additional_contributions` after each yearly top-up
- add regression tests for yearly contribution limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f59239f888321bf90e5f35ed3db54